### PR TITLE
Adding "trackingPosition" for 1.9

### DIFF
--- a/src/server/server.js
+++ b/src/server/server.js
@@ -152,6 +152,11 @@ var handlers = {
                 val: dimension
               },
               {
+                name: 'trackingPosition',
+                type: TAG.BYTE,
+                val: 0
+              },
+              {
                 name: 'height',
                 type: TAG.SHORT,
                 val: 128


### PR DESCRIPTION
Without trackingPosition in the NBT, 1.9 will always show a green arrow in the center of the map.