### PR TITLE
Fix broken maps

### DIFF
--- a/src/server/server.js
+++ b/src/server/server.js
@@ -137,6 +137,11 @@ var handlers = {
         name: '',
         val: [
           {
+            name: 'DataVersion',
+            type: TAG.INT,
+            val: 7856
+          },
+          {
             name: 'data',
             type: TAG.COMPOUND,
             val: [


### PR DESCRIPTION
The latest version creates broken maps because there is a new required value in the nbt "DataVersion".  

This adds the missing field.

Big fan of the project btw!