### PR TITLE
Changes on line 257 of main.js to allow modern Minecraft versions to use this tool.

### DIFF
--- a/src/client/main.js
+++ b/src/client/main.js
@@ -254,7 +254,7 @@ function createfile(ev) {
 
   var xcenter = Cookies.get('xcenter') || '0';
   var zcenter = Cookies.get('zcenter') || '0';
-  var dim = new String(Cookies.get('dimension') || 'minecraft:overworld');
+  var dim = Cookies.get('dimension') || 'minecraft:overworld';
 
   var mapnumber = parseInt($('#map_number').val(), 10) || 0;
 

--- a/src/client/main.js
+++ b/src/client/main.js
@@ -254,7 +254,7 @@ function createfile(ev) {
 
   var xcenter = Cookies.get('xcenter') || '0';
   var zcenter = Cookies.get('zcenter') || '0';
-  var dim = Cookies.get('dimension') || '0';
+  var dim = new String(Cookies.get('dimension') || 'minecraft:overworld');
 
   var mapnumber = parseInt($('#map_number').val(), 10) || 0;
 


### PR DESCRIPTION
As detailed in issue #91 by LosVocelos, modern Minecraft versions changed the dimension tag to be a string of "minecraft:[DIM]". Using the old version of a byte is no longer supported and results in the map reading "Unknown Map".

This changed line 257 to create an object that defaults to 'minecraft:overworld' if none is provided in Cookies.get('dimension').

As far as compatibility goes, this may break versions prior to 1.16, according to the [Minecraft Wiki](https://minecraft.wiki/w/Map_item_format#NBT_structure) page on map NBT.

> dimension: For <1.16 (byte): 0 = The [Overworld](https://minecraft.wiki/w/Overworld), -1 = [The Nether](https://minecraft.wiki/w/The_Nether), 1 = [The End](https://minecraft.wiki/w/The_End), any other value = a static image with no player pin. In >=1.16 this is the resource location of a dimension instead.