### PR TITLE
Add support for Minecraft 1.16 and later

### DIFF
--- a/assets/html/settings.html
+++ b/assets/html/settings.html
@@ -87,6 +87,15 @@
           </div>
         </div>
         <div class="form-group">
+          <label for="compatibility" class="col-sm-3 control-label">Compatibility</label>
+          <div class="col-sm-9">
+            <select name="compatibility" id="compatibility" class="form-control">
+              <option value="new">New (1.16 and later)</option>
+              <option value="legacy">Legacy (1.15 and earlier)</option>
+            </select>
+          </div>
+        </div>
+        <div class="form-group">
           <label for="dimension" class="col-sm-3 control-label">Dimension</label>
           <div class="col-sm-9">
             <select name="dimesion" id="dimension" class="form-control">

--- a/src/client/main.js
+++ b/src/client/main.js
@@ -254,6 +254,7 @@ function createfile(ev) {
 
   var xcenter = Cookies.get('xcenter') || '0';
   var zcenter = Cookies.get('zcenter') || '0';
+  var compatibility = Cookies.get('compatibility') || 'new';
   var dim = Cookies.get('dimension') || '0';
 
   var mapnumber = parseInt($('#map_number').val(), 10) || 0;
@@ -287,6 +288,7 @@ function createfile(ev) {
             map_item: JSON.stringify(map_item),
             x_center: xcenter,
             z_center: zcenter,
+            compatibility: compatibility,
             dimension: dim,
             randomid: randomid
           }, function(data) {
@@ -417,6 +419,10 @@ function list_settings() {
     '17w06a': 'Snapshot 17w06a',
     '112': 'Version 1.12 (2017)'
   };
+  var compatibilityToText = {
+    'new': 'New (1.16 and later)',
+    'legacy': 'Legacy (1.15 and earlier)'
+  };
   var dimensionToText = {
     '0': 'Overworld',
     '1': 'Nether',
@@ -436,6 +442,7 @@ function list_settings() {
   var sett_interpolation = interpolationToText[Cookies.get('interpolation') || 'standard'];
   var sett_xCenter = Cookies.get('xcenter') || '0';
   var sett_zCenter = Cookies.get('zcenter') || '0';
+  var sett_compatibility = compatibilityToText[Cookies.get('compatibility') || 'new'];
   var sett_dimension = dimensionToText[Cookies.get('dimension') || '0'];
 
   settings_string = '<tr><td>Color space</td><td>' + sett_colorSpace + '</td></tr>';
@@ -444,6 +451,7 @@ function list_settings() {
   settings_string += '<tr><td>Interpolation</td><td>' + sett_interpolation + '</td></tr>';
   settings_string += '<tr><td>X Center</td><td>' + sett_xCenter + '</td></tr>';
   settings_string += '<tr><td>Z Center</td><td>' + sett_zCenter + '</td></tr>';
+  settings_string += '<tr><td>Compatibility</td><td>' + sett_compatibility + '</td></tr>';
   settings_string += '<tr><td>Dimension</td><td>' + sett_dimension + '</td></tr>';
   $('#list_settings').html('<table style="margin-left: auto; margin-right: auto; width: 300px">' + settings_string + '</table>');
 }

--- a/src/client/settings.js
+++ b/src/client/settings.js
@@ -4,6 +4,7 @@ $(document).ready(function() {
   var colourSpace = Cookies.get('colourSpace') || 'laba';
   var xcenter = Cookies.get('xcenter') || '0';
   var zcenter = Cookies.get('zcenter') || '0';
+  var compatibility = Cookies.get('compatibility') || 'new';
   var dim = Cookies.get('dimension') || '0';
   var newColors = Cookies.get('newColors') || '181';
   var dithering = Cookies.get('dithering') || 'no';
@@ -13,6 +14,7 @@ $(document).ready(function() {
   $('#colorSpace').val(colourSpace);
   $('#x_center').val(xcenter);
   $('#z_center').val(zcenter);
+  $('#compatibility').val(compatibility);
   $('#dimension').val(dim);
   $('#newColors').val(newColors);
   $('#dithering').val(dithering);
@@ -29,6 +31,7 @@ function savesettings(event) {
   var colourSpace = $('#colorSpace').val();
   var xcenter = $('#x_center').val();
   var zcenter = $('#z_center').val();
+  var compatibility = $('#compatibility').val();
   var dim = $('#dimension').val();
   var newColors = $('#newColors').val();
   var dithering = $('#dithering').val();
@@ -37,6 +40,7 @@ function savesettings(event) {
   Cookies.set('colourSpace', colourSpace);
   Cookies.set('xcenter', xcenter);
   Cookies.set('zcenter', zcenter);
+  Cookies.set('compatibility', compatibility);
   Cookies.set('dimension', dim);
   Cookies.set('newColors', newColors);
   Cookies.set('dithering', dithering);

--- a/src/server/server.js
+++ b/src/server/server.js
@@ -105,6 +105,7 @@ var handlers = {
     var map_item_array;
     var x_center;
     var z_center;
+    var compatibility;
     var dimension;
     var randomid;
     try {
@@ -113,7 +114,16 @@ var handlers = {
       map_item_array = JSON.parse(decodedBody.map_item);
       x_center = parseInt(decodedBody.x_center, 10);
       z_center = parseInt(decodedBody.z_center, 10);
+      compatibility = decodedBody.compatibility;
       dimension = parseInt(decodedBody.dimension, 10);
+      let dimensionTag;
+      if (compatibility == 'new') {
+        const dims = ["minecraft:overworld", "minecraft:the_nether", "minecraft:the_end"];
+        dimensionTag = { name: 'dimension', type: TAG.STRING, val: dims[dimension] };
+      }
+      else {
+        dimensionTag = { name: 'dimension', type: TAG.BYTE, val: dimension };
+      }
       randomid = decodedBody.randomid;
       if (randomid !== "") {
         randomid+= "_";
@@ -150,11 +160,7 @@ var handlers = {
                 type: TAG.BYTE,
                 val: 0
               },
-              {
-                name: 'dimension',
-                type: TAG.BYTE,
-                val: dimension
-              },
+              dimensionTag,
               {
                 name: 'trackingPosition',
                 type: TAG.BYTE,

--- a/tests/mocha/test-server.js
+++ b/tests/mocha/test-server.js
@@ -42,12 +42,13 @@ describe('Server', function() {
       map_item: mapitem,
       x_center: "0",
       z_center: "0",
+      compatibility: "new",
       dimension: "0",
       randomid: ""
     };
     doPostRequest('/createfile', map, function(res, body) {
       expect(res.statusCode).to.equal(200);
-      expect(body).to.equal('112838b93ed25ab233e25004dfc3aea56f4ec16f');
+      expect(body).to.equal('e77750173999e2bca7bb8af86596b1af92a47aa5');
       done();
     });
   });


### PR DESCRIPTION
As described in [issue #91](https://github.com/djfun/mc-map-item-tool/issues/91), Minecraft has changed how the _dimension_ tag of the map is starting with version 1.16. This PR updates the tool to support both the old and new dimension tag formats.

This update introduces a new "Compatibility" option in the settings page, allowing users to select which Minecraft version they are using — **Legacy** (1.15 and earlier) or **New** (1.16 and later). The default is **New**.
- In **Legacy** mode, the application behaves as it did previously. 
- In the **New** mode (default), the application uses string-type tags _"minecraft:overworld", "minecraft:the_nether"_, or _"minecraft:the_end"_.